### PR TITLE
./benchmarks/benchs error logic

### DIFF
--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -22,6 +22,8 @@ const launchBenchs = function(path) {
 fs.access("./benchs", function(err) {
   if (err) {
     fs.access("./benchmarks/benchs", function(err) {
+      if(err)
+        return;
       launchBenchs("./benchmarks/benchs");
     });
   } else {


### PR DESCRIPTION
if './benchmarks/benchs' path throws an error, it shoud just return, not launchBenchs("./benchmarks/benchs");