### PR TITLE
Support for placeholder objects with `toSqlValue` functions.

### DIFF
--- a/documentation/callback-api.md
+++ b/documentation/callback-api.md
@@ -268,7 +268,7 @@ connection.query({dateStrings:true, sql:'SELECT now()'}, (err, rows, meta) => {
 
 ### Placeholder
 
-To avoid SQL Injection attacks, queries permit the use of a question mark as a placeholder.  The Connector escapes values according to their type.  You can use any native JavaScript type, Buffer, Readable or any object with a `toSqlString` method in these values.  All other objects are stringified using the `JSON.stringify` method.
+To avoid SQL Injection attacks, queries permit the use of a question mark as a placeholder.  The Connector escapes values according to their type.  You can use any native JavaScript type, Buffer, Readable or any object with a `toSqlString` or `toSqlValue`  method in these values.  All other objects are stringified using the `JSON.stringify` method.
 
 The Connector automatically streams objects that implement Readable.  In these cases, check the values on the following server system variables, as they may interfere:
 

--- a/documentation/promise-api.md
+++ b/documentation/promise-api.md
@@ -308,7 +308,7 @@ connection
 
 ### Placeholder
 
-To prevent SQL Injection attacks, queries permit the use of question marks as placeholders.  The Connection escapes values according to their type.  Values can be of native JavaScript types, Buffers, Readables, objects with `toSQLString` methods, or objects that can be stringified (that is, `JSON.stringfy`).
+To prevent SQL Injection attacks, queries permit the use of question marks as placeholders.  The Connection escapes values according to their type.  Values can be of native JavaScript types, Buffers, Readables, objects with `toSqlString` or `toSqlValue` methods, or objects that can be stringified (that is, `JSON.stringfy`).
 
 When streaming, objects that implement Readable are streamed automatically.  But, there are two server system variables that may interfere:
 

--- a/lib/cmd/common-binary-cmd.js
+++ b/lib/cmd/common-binary-cmd.js
@@ -36,6 +36,9 @@ class CommonBinary extends ResultSet {
         } else if (Buffer.isBuffer(value)) {
           flushed = out.writeInt8(0x00);
           flushed = out.writeLengthEncodedBuffer(value) || flushed;
+        } else if (typeof value.toSqlValue === "function") {
+            flushed = out.writeInt8(0x00);
+            flushed = out.writeLengthStringAscii("" + value.toSqlValue()) || flushed;
         } else if (typeof value.toSqlString === "function") {
           flushed = out.writeInt8(0x00);
           flushed = out.writeLengthEncodedString(String(value.toSqlString())) || flushed;

--- a/lib/cmd/common-text-cmd.js
+++ b/lib/cmd/common-text-cmd.js
@@ -37,6 +37,8 @@ class CommonText extends ResultSet {
           out.writeStringAscii("_BINARY '");
           out.writeBufferEscape(value);
           out.writeInt8(QUOTE);
+        } else if (typeof value.toSqlValue === "function") {
+          out.writeStringAscii("" + value.toSqlValue());
         } else if (typeof value.toSqlString === "function") {
           out.writeStringEscapeQuote(String(value.toSqlString()));
         } else {

--- a/lib/config/connection-options.js
+++ b/lib/config/connection-options.js
@@ -10,7 +10,7 @@ const urlFormat = /mariadb:\/\/(([^/@:]+)?(:([^/]+))?@)?(([^/:]+)(:([0-9]+))?)\/
  *   Only possible Objects are :
  *   - Buffer
  *   - Date
- *   - Object that implement toSqlString function
+ *   - Object that implements toSqlString or toSqlValue function
  *   - JSON object
  * + rowsAsArray (in mysql2) permit to have rows by index, not by name. Avoiding to parsing metadata string => faster
  */

--- a/test/integration/test-batch-callback.js
+++ b/test/integration/test-batch-callback.js
@@ -87,10 +87,13 @@ describe("batch callback", () => {
       f.toSqlString = () => {
         return "blabla";
       };
+      const n = {};
+      n.toSqlValue = n.toString = n.toJSON = () => "1";
       conn.batch(
-        "INSERT INTO `simpleBatch` values (1, ?, 2, ?, ?, ?, ?, 3)",
+        "INSERT INTO `simpleBatch` values (?, ?, 2, ?, ?, ?, ?, 3)",
         [
           [
+            n,
             true,
             "john😎🌶\\\\",
             new Date("2001-12-31 23:59:58"),
@@ -101,6 +104,7 @@ describe("batch callback", () => {
             }
           ],
           [
+            n,
             true,
             f,
             new Date("2001-12-31 23:59:58"),
@@ -111,6 +115,7 @@ describe("batch callback", () => {
             }
           ],
           [
+            n,
             false,
             { name: "jackमस्", val: "tt" },
             null,
@@ -121,6 +126,7 @@ describe("batch callback", () => {
             }
           ],
           [
+            n,
             0,
             null,
             new Date("2020-12-31 23:59:59"),
@@ -221,12 +227,14 @@ describe("batch callback", () => {
       f.toSqlString = () => {
         return "blabla";
       };
+      const n = {};
+      n.toSqlValue = n.toString = n.toJSON = () => "1";
       conn.batch(
         {
           sql: "INSERT INTO `simpleBatchWithOptions` values (?, ?)",
           maxAllowedPacket: 1048576
         },
-        [[1, new Date("2001-12-31 23:59:58")], [2, new Date("2001-12-31 23:59:58")]],
+        [[n, new Date("2001-12-31 23:59:58")], [2, new Date("2001-12-31 23:59:58")]],
         (err, res) => {
           if (err) {
             return conn.end(() => {

--- a/test/integration/test-batch.js
+++ b/test/integration/test-batch.js
@@ -84,9 +84,12 @@ describe("batch", () => {
         f.toSqlString = () => {
           return "blabla";
         };
+        const n = {};
+        n.toSqlValue = n.toString = n.toJSON = () => "1";
         conn
-          .batch("INSERT INTO `simpleBatch` values (1, ?, 2, ?, ?, ?, ?, 3)", [
+          .batch("INSERT INTO `simpleBatch` values (?, ?, 2, ?, ?, ?, ?, 3)", [
             [
+              n,
               true,
               "john😎🌶\\\\",
               new Date("2001-12-31 23:59:58"),
@@ -97,6 +100,7 @@ describe("batch", () => {
               }
             ],
             [
+              n,
               true,
               f,
               new Date("2001-12-31 23:59:58"),
@@ -107,6 +111,7 @@ describe("batch", () => {
               }
             ],
             [
+              n,
               false,
               { name: "jackमस्", val: "tt" },
               null,
@@ -117,6 +122,7 @@ describe("batch", () => {
               }
             ],
             [
+              n,
               0,
               null,
               new Date("2020-12-31 23:59:59"),
@@ -223,13 +229,15 @@ describe("batch", () => {
         f.toSqlString = () => {
           return "blabla";
         };
+        const n = {};
+        n.toSqlValue = n.toString = n.toJSON = () => "1";
         conn
           .batch(
             {
               sql: "INSERT INTO `simpleBatchWithOptions` values (?, ?)",
               maxAllowedPacket: 1048576
             },
-            [[1, new Date("2001-12-31 23:59:58")], [2, new Date("2001-12-31 23:59:58")]]
+            [[n, new Date("2001-12-31 23:59:58")], [2, new Date("2001-12-31 23:59:58")]]
           )
           .then(res => {
             assert.equal(res.affectedRows, 2);


### PR DESCRIPTION
Adds support for placeholder objects with `toSqlValue` functions.

Similar to how objects with `toSqlString` functions work, this function does not wrap the value with quotes. This is useful for parameterizing ridiculous numeric values or custom functions.

For example:

```js
const MaxValue = {
  toSqlValue: () => '18446744073709551615'
}

const res = await db.query('SELECT * FROM `table` LIMIT ?, ?', [10, MaxValue]);
```

If there's a better way to implement this, please let me know!

Thanks,
-Kevin