### PR TITLE
[fix] Handle LOCAL INFILE read errors

### DIFF
--- a/lib/cmd/resultset.js
+++ b/lib/cmd/resultset.js
@@ -488,35 +488,30 @@ class ResultSet extends Command {
       return (this.onPacketReceive = this.readResponsePacket);
     }
 
-    fs.access(fileName, (fs.constants || fs).R_OK, err => {
-      if (err) {
-        out.writeEmptyPacket();
-        const error = Errors.createError(
-          'LOCAL INFILE command failed: ' + err.message,
-          false,
-          info,
-          '22000',
-          Errors.ER_LOCAL_INFILE_NOT_READABLE
-        );
-
-        process.nextTick(this.reject, error);
-        this.reject = null;
-        this.resolve = null;
-        return (this.onPacketReceive = this.readResponsePacket);
+    // this.sequenceNo = 2;
+    // this.compressSequenceNo = 2;
+    const stream = fs.createReadStream(fileName);
+    stream.on('error', err => {
+      out.writeEmptyPacket();
+      const error = Errors.createError(
+        'LOCAL INFILE command failed: ' + err.message,
+        false,
+        info,
+        '22000',
+        Errors.ER_LOCAL_INFILE_NOT_READABLE
+      );
+      process.nextTick(this.reject, error);
+      this.reject = null;
+      this.resolve = null;
+    });
+    stream.on('data', chunk => {
+      out.writeBuffer(chunk, 0, chunk.length);
+    });
+    stream.on('end', () => {
+      if (!out.isEmpty()) {
+        out.flushBuffer(false);
       }
-
-      // this.sequenceNo = 2;
-      // this.compressSequenceNo = 2;
-      const stream = fs.createReadStream(fileName);
-      stream.on('data', chunk => {
-        out.writeBuffer(chunk, 0, chunk.length);
-      });
-      stream.on('end', () => {
-        if (!out.isEmpty()) {
-          out.flushBuffer(false);
-        }
-        out.writeEmptyPacket();
-      });
+      out.writeEmptyPacket();
     });
     this.onPacketReceive = this.readResponsePacket;
   }

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "denque": "^1.4.0",
     "iconv-lite": "^0.4.24",
     "long": "^4.0.0",
-    "moment-timezone": "^0.5.25"
+    "moment-timezone": "^0.5.25",
+    "@types/geojson": "^7946.0.7",
+    "@types/node": "^11.11.5"
   },
   "devDependencies": {
-    "@types/geojson": "^7946.0.7",
-    "@types/node": "^11.11.5",
     "@typescript-eslint/eslint-plugin": "^1.5.0",
     "@typescript-eslint/parser": "^1.5.0",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
Adds an error event listener to the LOCAL INFILE read stream to handle read errors generated midway through reading the file. Also removes the previous fs.access(...) check as there is a race condition between validating whether the file exists and is readable and actually trying to read it.

If the file does not exist, is not readable, or some other error occurs while trying to read it then they will all be handled the same way.

This should handle the situations described in https://jira.mariadb.org/browse/CONJS-79

I haven't included a test of an intermittent failure by mocking the error mid read (it's a bit more complicated than I have time for right now) but this changes passes all the existing LOCAL INFILE tests including the missing file ones.

Would be good for someone to spot check the return values and error situations as I'm not too familiar with the code base so inferred the error handling based on how it was handled in the previous async access check.