### PR TITLE
emit connection object on new connection

### DIFF
--- a/documentation/callback-api.md
+++ b/documentation/callback-api.md
@@ -201,6 +201,22 @@ Specific options for pools are :
 | **`minDelayValidation`** | When asking a connection to pool, the pool will validate the connection state. "minDelayValidation" permits disabling this validation if the connection has been borrowed recently avoiding useless verifications in case of frequent reuse of connections. 0 means validation is done each time the connection is asked. (in ms) |*integer*| 500|
 | **`noControlAfterUse`** | After giving back connection to pool (connection.end) connector will reset or rollback connection to ensure a valid state. This option permit to disable those controls|*boolean*| false|
 
+#### Pool events
+
+|event|description|
+|---:|---|
+| **`new-conn`** | This event emits the connection object when a new connection is added to the pool.  |
+| **`remove-conn`** | This event is emitted when a connection is removed from the pool. |
+| **`idle-conn`** | This event is emitted when a connection is released back into the pool. |
+
+**Example:**
+
+```javascript
+pool.on('new-conn', function (conn) {
+  conn.query('SET SESSION auto_increment_increment=1')
+});
+```
+
 ### `createPoolCluster(options) → PoolCluster`
 
 > * `options`: *JSON* [poolCluster options](#poolCluster-options)
@@ -220,7 +236,7 @@ cluster.add("slave1", { host: 'mydb2.com', user: 'myUser', connectionLimit: 5 })
 cluster.add("slave2", { host: 'mydb3.com', user: 'myUser', connectionLimit: 5 });
 
 //getting a connection from slave1 or slave2 using round-robin
-cluster.getConnection(/^slave*$, "RR", (err, conn) => {
+cluster.getConnection(/^slave*$/, "RR", (err, conn) => {
   conn.query("SELECT 1", (err, rows) => {
      conn.end();
      return row[0]["@node"];
@@ -503,7 +519,7 @@ pool.getConnection((err, conn => {
     console.log("connected ! connection id is " + conn.threadId);
     conn.end(); //release to pool
   }
-})
+}));
 ```
 
 ## `pool.query(sql[, values][, callback])`

--- a/lib/pool-base.js
+++ b/lib/pool-base.js
@@ -379,7 +379,7 @@ function PoolBase(options, processTask, createConnectionPool, pingPromise) {
     connectionInCreation = false;
     idleConnections.push(conn);
     pool.emit('idle-conn');
-    pool.emit('new-conn');
+    process.nextTick(() => pool.emit('new-conn', conn));
   };
 
   this._releaseConnection = function(conn) {

--- a/test/integration/test-pool.js
+++ b/test/integration/test-pool.js
@@ -857,4 +857,21 @@ describe('Pool', () => {
         .catch(done);
     }, 4000);
   });
+
+  it('new-conn event emits connection', function(done) {
+    this.timeout(5000);
+    const pool = base.createPool({
+      connectionLimit: 10,
+      minimumIdle: 4,
+      idleTimeout: 2
+    });
+
+    pool.on('new-conn', conn => {
+      assert.isTrue(conn !== undefined);
+      pool
+        .end()
+        .then(() => done())
+        .catch(done);
+    });
+  });
 });


### PR DESCRIPTION
coming from [mysql](https://github.com/mysqljs/mysql), I really miss having the ability to set up session settings when a new connection becomes available.

https://github.com/mysqljs/mysql#connection
```javascript
pool.on('new-conn', function (conn) {
  conn.query('SET SESSION auto_increment_increment=1')
});
```
The only caveat is that the event name is `new-conn` whereas in mysql it was `connection`. As long it's documented it's not a big deal.