### PR TITLE
fix missing parameter for ordered selector

### DIFF
--- a/lib/pool-cluster.js
+++ b/lib/pool-cluster.js
@@ -245,7 +245,7 @@ function PoolCluster(args) {
       retry < nodeList.length - 1
     ) {
       retry++;
-      nodeKey = selectorFct(nodeList);
+      nodeKey = selectorFct(nodeList, retry);
     }
     return nodeKey;
   };


### PR DESCRIPTION
Fix for this [issue](https://github.com/MariaDB/mariadb-connector-nodejs/issues), added the missing parameter for following scenery:

- using cluster pool
- with ordered selector
- first cluster down

it above case, the current code will cause an error as explained in the issue.

